### PR TITLE
refactor: rename `fast_livo` to `fast_livo2`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(fast_livo)
+project(fast_livo2)
 
 set(CMAKE_BUILD_TYPE "Release")
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ source ~/catkin_ws/devel/setup.bash
 Download our collected rosbag files via OneDrive ([**FAST-LIVO2-Dataset**](https://connecthkuhk-my.sharepoint.com/:f:/g/personal/zhengcr_connect_hku_hk/ErdFNQtjMxZOorYKDTtK4ugBkogXfq1OfDm90GECouuIQA?e=KngY9Z)). 
 
 ```
-roslaunch fast_livo mapping_avia.launch
+roslaunch fast_livo2 mapping_avia.launch
 rosbag play YOUR_DOWNLOADED.bag
 ```
 

--- a/launch/mapping_avia.launch
+++ b/launch/mapping_avia.launch
@@ -3,14 +3,14 @@
 
 	<arg name="rviz" default="true" />
 
-	<rosparam command="load" file="$(find fast_livo)/config/avia.yaml" />
+	<rosparam command="load" file="$(find fast_livo2)/config/avia.yaml" />
 
-	<node pkg="fast_livo" type="fastlivo_mapping" name="laserMapping" output="screen">
-		<rosparam file="$(find fast_livo)/config/camera_pinhole.yaml" />
+	<node pkg="fast_livo2" type="fastlivo_mapping" name="laserMapping" output="screen">
+		<rosparam file="$(find fast_livo2)/config/camera_pinhole.yaml" />
 	</node>
 	
 	<group if="$(arg rviz)">
-		<node launch-prefix="nice" pkg="rviz" type="rviz" name="rviz" args="-d $(find fast_livo)/rviz_cfg/fast_livo2.rviz" />
+		<node launch-prefix="nice" pkg="rviz" type="rviz" name="rviz" args="-d $(find fast_livo2)/rviz_cfg/fast_livo2.rviz" />
 	</group>
 	
 	<node pkg="image_transport" type="republish" name="republish" args="compressed in:=/left_camera/image raw out:=/left_camera/image" output="screen" respawn="true"/>

--- a/launch/mapping_avia_marslvig.launch
+++ b/launch/mapping_avia_marslvig.launch
@@ -3,14 +3,14 @@
 
 	<arg name="rviz" default="true" />
 
-	<rosparam command="load" file="$(find fast_livo)/config/MARS_LVIG.yaml" />
+	<rosparam command="load" file="$(find fast_livo2)/config/MARS_LVIG.yaml" />
 
-	<node pkg="fast_livo" type="fastlivo_mapping" name="laserMapping" output="screen">
-		<rosparam file="$(find fast_livo)/config/camera_MARS_LVIG.yaml" />
+	<node pkg="fast_livo2" type="fastlivo_mapping" name="laserMapping" output="screen">
+		<rosparam file="$(find fast_livo2)/config/camera_MARS_LVIG.yaml" />
 	</node>
 	
 	<group if="$(arg rviz)">
-		<node launch-prefix="nice" pkg="rviz" type="rviz" name="rviz" args="-d $(find fast_livo)/rviz_cfg/M300.rviz" />
+		<node launch-prefix="nice" pkg="rviz" type="rviz" name="rviz" args="-d $(find fast_livo2)/rviz_cfg/M300.rviz" />
 	</group>
 	
 	<node pkg="image_transport" type="republish" name="republish" args="compressed in:=/left_camera/image raw out:=/left_camera/image" output="screen" respawn="true"/>

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package>
-  <name>fast_livo</name>
+  <name>fast_livo2</name>
   <version>0.0.0</version>
 
   <description>

--- a/scripts/colmap_output.sh
+++ b/scripts/colmap_output.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 TARGET_DIRS=(
-    "$(rospack find fast_livo)/Log/Colmap/images"
-    "$(rospack find fast_livo)/Log/Colmap/sparse/0"
+    "$(rospack find fast_livo2)/Log/Colmap/images"
+    "$(rospack find fast_livo2)/Log/Colmap/sparse/0"
 )
 
 for dir in "${TARGET_DIRS[@]}"; do


### PR DESCRIPTION
- Avoid naming conflict with installed `fast_livo`.
