### PR TITLE
Use configurable voxel_size in plane queries (vio.cpp)

### DIFF
--- a/include/vio.h
+++ b/include/vio.h
@@ -108,6 +108,8 @@ public:
 
   double img_point_cov, outlier_threshold, ncc_thre;
   
+  float plane_voxel_size;
+
   SubSparseMap *visual_submap;
   std::vector<std::vector<V3D>> rays_with_sample_points;
 

--- a/src/LIVMapper.cpp
+++ b/src/LIVMapper.cpp
@@ -138,6 +138,7 @@ void LIVMapper::initializeComponents()
   vio_manager->grid_n_width = grid_n_width;
   vio_manager->grid_n_height = grid_n_height;
   vio_manager->patch_pyrimid_level = patch_pyrimid_level;
+  vio_manager->plane_voxel_size = voxelmap_manager->config_setting_.max_voxel_size_;
   vio_manager->exposure_estimate_en = exposure_estimate_en;
   vio_manager->colmap_output_en = colmap_output_en;
   vio_manager->initializeVIO();

--- a/src/vio.cpp
+++ b/src/vio.cpp
@@ -568,6 +568,11 @@ void VIOManager::retrieveFromVisualSparseMap(cv::Mat img, vector<pointWithVar> &
         }
         else
         {
+          for (int j = 0; j < 3; j++)
+          {
+            loc_xyz[j] = floor(sample_point_w[j] / plane_voxel_size);
+            if (loc_xyz[j] < 0) { loc_xyz[j] -= 1.0; }
+          }
           VOXEL_LOCATION sample_pos(loc_xyz[0], loc_xyz[1], loc_xyz[2]);
           auto iter = plane_map.find(sample_pos);
           if (iter != plane_map.end())
@@ -983,7 +988,7 @@ void VIOManager::updateReferencePatch(const unordered_map<VOXEL_LOCATION, VoxelO
     float loc_xyz[3];
     for (int j = 0; j < 3; j++)
     {
-      loc_xyz[j] = p_w[j] / 0.5;
+      loc_xyz[j] = p_w[j] / plane_voxel_size;
       if (loc_xyz[j] < 0) { loc_xyz[j] -= 1.0; }
     }
     VOXEL_LOCATION position((int64_t)loc_xyz[0], (int64_t)loc_xyz[1], (int64_t)loc_xyz[2]);


### PR DESCRIPTION
## What is problem?
Hello
I think your code is really great.
While reading through code, I found one issue: 
In `vio.cpp`, the `voxel_size` for the plane map query is set to `0.5`, 
which can be different from the value set in the config file.

Thus, I have updated the code so that `vio.cpp` uses the `voxel_size` specified in `voxel_map`.

Thank you.

### Modified Files
- `vio.cpp` : Update the plane query to utilize the `plane_voxel_size`
- `vio.h` : Define the variable `plane_voxel_size`
- `LVIMapper.cpp` : Initialize the variable `plane_voxel_size`
